### PR TITLE
docs: add Yarn installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,16 @@
 
 ## 📦 Installation
 
+### Using npm
+
 ```bash
 npm install -g releasy-it
+```
+
+### Using Yarn
+
+```bash
+yarn global add releasy-it
 ```
 
 ---


### PR DESCRIPTION
### What’s Changed
- Updated the README.md to include Yarn-based installation steps alongside npm.
- Clarified install section for better accessibility to Yarn users.

### Why
Not all developers use npm — this update ensures that Yarn users can install and use `releasy-it` just as easily.

### Related
- Package: [releasy-it on npm](https://www.npmjs.com/package/releasy-it)
